### PR TITLE
feat: improve codegen command interface naming for RN 0.81+ compatibility

### DIFF
--- a/src/spec/RNCNaverMapViewNativeComponent.ts
+++ b/src/spec/RNCNaverMapViewNativeComponent.ts
@@ -216,7 +216,7 @@ interface Props extends ViewProps {
 
 type ComponentType = HostComponent<Props>;
 
-interface NaverMapNativeCommands {
+interface NativeCommands {
   screenToCoordinate: (
     ref: React.ElementRef<ComponentType>,
     x: Double,
@@ -277,15 +277,14 @@ interface NaverMapNativeCommands {
 }
 
 export default codegenNativeComponent<Props>('RNCNaverMapView');
-export const Commands: NaverMapNativeCommands =
-  codegenNativeCommands<NaverMapNativeCommands>({
-    supportedCommands: [
-      'screenToCoordinate',
-      'coordinateToScreen',
-      'animateCameraTo',
-      'animateCameraBy',
-      'cancelAnimation',
-      'animateRegionTo',
-      'setLocationTrackingMode',
-    ],
-  });
+export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: [
+    'screenToCoordinate',
+    'coordinateToScreen',
+    'animateCameraTo',
+    'animateCameraBy',
+    'cancelAnimation',
+    'animateRegionTo',
+    'setLocationTrackingMode',
+  ],
+});


### PR DESCRIPTION
## Type of change

- [x] Enhance (enhance performance, api, etc)

## What does this change?

This PR improves React Native codegen compatibility by renaming the `NaverMapNativeCommands` interface to `NativeCommands`. This follows React Native's codegen naming conventions and ensures better compatibility with React Native 0.81+.

**Changes:**
- Renamed `NaverMapNativeCommands` interface to `NativeCommands` in `RNCNaverMapViewNativeComponent.ts`
- Maintains all existing command functionality without breaking changes