### PR TITLE
chore(example): migrate from deprecated SafeAreaView to react-native-safe-area-context

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1681,6 +1681,96 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
+  - react-native-safe-area-context (5.6.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - react-native-safe-area-context/common (= 5.6.1)
+    - react-native-safe-area-context/fabric (= 5.6.1)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-safe-area-context/common (5.6.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-safe-area-context/fabric (5.6.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - react-native-slider (4.5.7):
     - boost
     - DoubleConversion
@@ -2289,6 +2379,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-slider (from `../../node_modules/@react-native-community/slider`)"
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
@@ -2415,6 +2506,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   react-native-slider:
     :path: "../../node_modules/@react-native-community/slider"
   React-NativeModulesApple:
@@ -2528,6 +2621,7 @@ SPEC CHECKSUMS:
   React-logger: dce52a571ba0e0149c3f0fcc6866cbc0c8552c5e
   React-Mapbuffer: f5754c33877eaf36e4c76c613b35615a181c85c5
   React-microtasksnativemodule: 23df6374a3ac422d8c2927839bcaeed61fee3dad
+  react-native-safe-area-context: 8ed800930eb7d0b6651218f69656e823d37b6ef7
   react-native-slider: c434f7094c9500dfa1176931f48e5957872818f8
   React-NativeModulesApple: e16d5c133019987285f001fbf1461a861e40426f
   React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626
@@ -2560,7 +2654,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 3267432b637c9b38e86961b287f784ee1b08dde0
   ReactCodegen: 4f2c5fc558612d65fa4b1603e0b1a077f0923a25
   ReactCommon: b028d09a66e60ebd83ca59d8cc9a1216360db147
-  RNPermissions: 6e783a3b1107449683d03fcf1c86a2e3f2f7ea7c
+  RNPermissions: ad33a305df700902acd482764b4885d2dea3a78e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 0c4b7d2aacc910a1f702694fa86be830386f4ceb
 

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,8 @@
     "@react-native/new-app-screen": "catalog:",
     "react": "catalog:",
     "react-native": "catalog:",
-    "react-native-permissions": "^5.4.1"
+    "react-native-permissions": "^5.4.1",
+    "react-native-safe-area-context": "^5.6.1"
   },
   "devDependencies": {
     "@babel/core": "catalog:",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
   Platform,
-  SafeAreaView,
   ScrollView,
   Text,
   TouchableOpacity,
@@ -13,6 +12,7 @@ import {
   requestLocationAccuracy,
   requestMultiple,
 } from 'react-native-permissions';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { ArrowheadPathScreen } from './screens/ArrowheadPathScreen';
 import { CameraScreen } from './screens/CameraScreen';
 import { CircleScreen } from './screens/CircleScreen';
@@ -79,99 +79,78 @@ export default function App() {
 
   const handleBack = () => setCurrentScreen(null);
 
-  if (currentScreen === null) {
-    return (
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
-        <View
-          style={{
-            paddingVertical: 20,
-            paddingHorizontal: 16,
-            borderBottomWidth: 1,
-            borderBottomColor: '#333',
-          }}
-        >
-          <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>
-            Naver Map Examples
-          </Text>
-        </View>
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{ padding: 16, gap: 12 }}
-        >
-          {SCREENS.map((screen) => (
-            <TouchableOpacity
-              key={screen.id}
-              onPress={() => setCurrentScreen(screen.id)}
+  const renderScreen = () => {
+    switch (currentScreen) {
+      case 'common':
+        return <CommonScreen onBack={handleBack} />;
+      case 'camera':
+        return <CameraScreen onBack={handleBack} />;
+      case 'marker':
+        return <MarkerScreen onBack={handleBack} />;
+      case 'circle':
+        return <CircleScreen onBack={handleBack} />;
+      case 'ground':
+        return <GroundScreen onBack={handleBack} />;
+      case 'path':
+        return <PathScreen onBack={handleBack} />;
+      case 'multipath':
+        return <MultiPathScreen onBack={handleBack} />;
+      case 'polygon':
+        return <PolygonScreen onBack={handleBack} />;
+      case 'polyline':
+        return <PolylineScreen onBack={handleBack} />;
+      case 'arrowhead':
+        return <ArrowheadPathScreen onBack={handleBack} />;
+      case 'clustering':
+        return <ClusteringScreen onBack={handleBack} />;
+      case 'locationOverlay':
+        return <LocationOverlayScreen onBack={handleBack} />;
+      case 'cities':
+        return <CitiesScreen onBack={handleBack} />;
+      default:
+        return (
+          <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
+            <View
               style={{
-                backgroundColor: '#1a1a1a',
-                paddingVertical: 16,
-                paddingHorizontal: 20,
-                borderRadius: 8,
-                borderWidth: 1,
-                borderColor: '#333',
+                paddingVertical: 20,
+                paddingHorizontal: 16,
+                borderBottomWidth: 1,
+                borderBottomColor: '#333',
               }}
             >
-              <Text style={{ color: '#fff', fontSize: 16, fontWeight: '600' }}>
-                {screen.title}
+              <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>
+                Naver Map Examples
               </Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
-      </SafeAreaView>
-    );
-  }
+            </View>
+            <ScrollView
+              style={{ flex: 1 }}
+              contentContainerStyle={{ padding: 16, gap: 12 }}
+            >
+              {SCREENS.map((screen) => (
+                <TouchableOpacity
+                  key={screen.id}
+                  onPress={() => setCurrentScreen(screen.id)}
+                  style={{
+                    backgroundColor: '#1a1a1a',
+                    paddingVertical: 16,
+                    paddingHorizontal: 20,
+                    borderRadius: 8,
+                    borderWidth: 1,
+                    borderColor: '#333',
+                  }}
+                >
+                  <Text
+                    style={{ color: '#fff', fontSize: 16, fontWeight: '600' }}
+                  >
+                    {screen.title}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          </SafeAreaView>
+        );
+    }
+  };
 
-  if (currentScreen === 'common') {
-    return <CommonScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'camera') {
-    return <CameraScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'marker') {
-    return <MarkerScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'circle') {
-    return <CircleScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'ground') {
-    return <GroundScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'path') {
-    return <PathScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'multipath') {
-    return <MultiPathScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'polygon') {
-    return <PolygonScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'polyline') {
-    return <PolylineScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'arrowhead') {
-    return <ArrowheadPathScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'clustering') {
-    return <ClusteringScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'locationOverlay') {
-    return <LocationOverlayScreen onBack={handleBack} />;
-  }
-
-  if (currentScreen === 'cities') {
-    return <CitiesScreen onBack={handleBack} />;
-  }
-
-  return null;
+  return <SafeAreaProvider>{renderScreen()}</SafeAreaProvider>;
 }

--- a/example/src/components/Header.tsx
+++ b/example/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SafeAreaView, Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 
 export const Header = ({
   title,
@@ -9,33 +9,31 @@ export const Header = ({
   onBack: () => void;
 }) => {
   return (
-    <SafeAreaView style={{ backgroundColor: '#000' }}>
-      <View
+    <View
+      style={{
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        backgroundColor: '#000',
+        borderBottomWidth: 1,
+        borderBottomColor: '#333',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+      }}
+    >
+      <TouchableOpacity
+        onPress={onBack}
         style={{
-          paddingHorizontal: 16,
-          paddingVertical: 12,
-          backgroundColor: '#000',
-          borderBottomWidth: 1,
-          borderBottomColor: '#333',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: 12,
+          padding: 4,
         }}
       >
-        <TouchableOpacity
-          onPress={onBack}
-          style={{
-            padding: 4,
-          }}
-        >
-          <Text style={{ color: '#fff', fontSize: 18, fontWeight: 'bold' }}>
-            ←
-          </Text>
-        </TouchableOpacity>
-        <Text style={{ color: '#fff', fontSize: 16, fontWeight: 'bold' }}>
-          {title}
+        <Text style={{ color: '#fff', fontSize: 18, fontWeight: 'bold' }}>
+          ←
         </Text>
-      </View>
-    </SafeAreaView>
+      </TouchableOpacity>
+      <Text style={{ color: '#fff', fontSize: 16, fontWeight: 'bold' }}>
+        {title}
+      </Text>
+    </View>
   );
 };

--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -3,6 +3,7 @@ import {
   type NaverMapViewRef,
 } from '@mj-studio/react-native-naver-map';
 import React, { useRef, useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Btn } from '../component/components';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
@@ -30,7 +31,7 @@ export const CameraScreen = ({ onBack }: { onBack: () => void }) => {
   const [camera, setCamera] = useState(Cameras.Jeju);
 
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Camera Controls'} onBack={onBack} />
       <ScreenLayout
         mapRef={ref}
@@ -135,6 +136,6 @@ export const CameraScreen = ({ onBack }: { onBack: () => void }) => {
           </>
         }
       />
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/CircleScreen.tsx
+++ b/example/src/screens/CircleScreen.tsx
@@ -1,5 +1,6 @@
 import { NaverMapCircleOverlay } from '@mj-studio/react-native-naver-map';
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -13,7 +14,7 @@ const Cameras = {
 
 export const CircleScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Circle Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -31,6 +32,6 @@ export const CircleScreen = ({ onBack }: { onBack: () => void }) => {
           onTap={() => console.log('Circle tapped')}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/CitiesScreen.tsx
+++ b/example/src/screens/CitiesScreen.tsx
@@ -1,6 +1,7 @@
 import { formatJson } from '@mj-studio/js-util';
 import { NaverMapMarkerOverlay } from '@mj-studio/react-native-naver-map';
 import React, { useState, useTransition } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 import { type City, getCitiesByRegion } from '../db/CityDatabase';
@@ -18,7 +19,7 @@ export const CitiesScreen = ({ onBack }: { onBack: () => void }) => {
   const [, startTransition] = useTransition();
 
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Cities (Performance Test)'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -50,6 +51,6 @@ export const CitiesScreen = ({ onBack }: { onBack: () => void }) => {
           />
         ))}
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/ClusteringScreen.tsx
+++ b/example/src/screens/ClusteringScreen.tsx
@@ -1,6 +1,7 @@
 import { generateArray } from '@mj-studio/js-util';
 import { type ClusterMarkerProp } from '@mj-studio/react-native-naver-map';
 import React, { useMemo, useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Btn } from '../component/components';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
@@ -49,7 +50,7 @@ export const ClusteringScreen = ({ onBack }: { onBack: () => void }) => {
   }, [hash]);
 
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Clustering'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -68,6 +69,6 @@ export const ClusteringScreen = ({ onBack }: { onBack: () => void }) => {
           </>
         }
       />
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/CommonScreen.tsx
+++ b/example/src/screens/CommonScreen.tsx
@@ -1,5 +1,6 @@
 import { type MapType } from '@mj-studio/react-native-naver-map';
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Btn, Range, Toggle } from '../component/components';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
@@ -36,7 +37,7 @@ export const CommonScreen = ({ onBack }: { onBack: () => void }) => {
   const [rerenderKey, setRerenderKey] = useState(0);
 
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Common Settings'} onBack={onBack} />
       <ScreenLayout
         showMap={rerenderKey % 2 === 0}
@@ -129,6 +130,6 @@ export const CommonScreen = ({ onBack }: { onBack: () => void }) => {
           </>
         }
       />
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/GroundScreen.tsx
+++ b/example/src/screens/GroundScreen.tsx
@@ -3,6 +3,7 @@ import {
   type Region,
 } from '@mj-studio/react-native-naver-map';
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -25,7 +26,7 @@ const Regions = {
 
 export const GroundScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Ground Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -38,6 +39,6 @@ export const GroundScreen = ({ onBack }: { onBack: () => void }) => {
           onTap={() => console.log('Ground overlay tapped')}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/LocationOverlayScreen.tsx
+++ b/example/src/screens/LocationOverlayScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Text } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Btn, Toggle } from '../component/components';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
@@ -17,7 +18,7 @@ export const LocationOverlayScreen = ({ onBack }: { onBack: () => void }) => {
   const [locationOverlayBearing, setLocationOverlayBearing] = useState(0);
 
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Location Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -72,6 +73,6 @@ export const LocationOverlayScreen = ({ onBack }: { onBack: () => void }) => {
           </>
         }
       />
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/MarkerScreen.tsx
+++ b/example/src/screens/MarkerScreen.tsx
@@ -1,6 +1,7 @@
 import { NaverMapMarkerOverlay } from '@mj-studio/react-native-naver-map';
 import React from 'react';
 import { Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -14,7 +15,7 @@ const Cameras = {
 
 export const MarkerScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Marker Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -80,6 +81,6 @@ export const MarkerScreen = ({ onBack }: { onBack: () => void }) => {
           image={{ httpUri: 'https://picsum.photos/1000/1201' }}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/MultiPathScreen.tsx
+++ b/example/src/screens/MultiPathScreen.tsx
@@ -1,5 +1,6 @@
 import { NaverMapMultiPathOverlay } from '@mj-studio/react-native-naver-map';
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -13,7 +14,7 @@ const Cameras = {
 
 export const MultiPathScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Multi Path Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -64,6 +65,6 @@ export const MultiPathScreen = ({ onBack }: { onBack: () => void }) => {
           onTap={() => console.log('MultiPath tapped!')}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/PathScreen.tsx
+++ b/example/src/screens/PathScreen.tsx
@@ -1,5 +1,6 @@
 import { NaverMapPathOverlay } from '@mj-studio/react-native-naver-map';
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -13,7 +14,7 @@ const Cameras = {
 
 export const PathScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Path Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -35,6 +36,6 @@ export const PathScreen = ({ onBack }: { onBack: () => void }) => {
           outlineWidth={1}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/PolygonScreen.tsx
+++ b/example/src/screens/PolygonScreen.tsx
@@ -1,5 +1,6 @@
 import { NaverMapPolygonOverlay } from '@mj-studio/react-native-naver-map';
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -13,7 +14,7 @@ const Cameras = {
 
 export const PolygonScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Polygon Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -31,6 +32,6 @@ export const PolygonScreen = ({ onBack }: { onBack: () => void }) => {
           ]}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/example/src/screens/PolylineScreen.tsx
+++ b/example/src/screens/PolylineScreen.tsx
@@ -1,5 +1,6 @@
 import { NaverMapPolylineOverlay } from '@mj-studio/react-native-naver-map';
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '../components/Header';
 import { ScreenLayout } from '../components/ScreenLayout';
 
@@ -13,7 +14,7 @@ const Cameras = {
 
 export const PolylineScreen = ({ onBack }: { onBack: () => void }) => {
   return (
-    <>
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#000' }}>
       <Header title={'Polyline Overlay'} onBack={onBack} />
       <ScreenLayout
         mapProps={{
@@ -29,6 +30,6 @@ export const PolylineScreen = ({ onBack }: { onBack: () => void }) => {
           ]}
         />
       </ScreenLayout>
-    </>
+    </SafeAreaView>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       react-native-permissions:
         specifier: ^5.4.1
         version: 5.4.2(react-native@0.80.0(@babel/core@7.28.4)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-safe-area-context:
+        specifier: ^5.6.1
+        version: 5.6.1(react-native@0.80.0(@babel/core@7.28.4)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -5158,6 +5161,12 @@ packages:
     peerDependenciesMeta:
       react-native-windows:
         optional: true
+
+  react-native-safe-area-context@5.6.1:
+    resolution: {integrity: sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native@0.80.0:
     resolution: {integrity: sha512-b9K1ygb2MWCBtKAodKmE3UsbUuC29Pt4CrJMR0ocTA8k+8HJQTPleBPDNKL4/p0P01QO9aL/gZUddoxHempLow==}
@@ -11821,6 +11830,11 @@ snapshots:
       fast-glob: 3.3.3
 
   react-native-permissions@5.4.2(react-native@0.80.0(@babel/core@7.28.4)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.80.0(@babel/core@7.28.4)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@types/react@19.1.0)(react@19.1.0)
+
+  react-native-safe-area-context@5.6.1(react-native@0.80.0(@babel/core@7.28.4)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.4)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@types/react@19.1.0)(react@19.1.0)


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [X] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

기존 SafeAreaView 가 안드로이드 sdk 35 이상에서 적용되는 edge to edge 를 지원하지 않다보니 example 프로젝트에서 상,하단 컨텐츠가 가려지는 현상이 발생하고 있습니다. 이를 해결하기위해 [RN 0.81 이상의 문서에서 권고하는대로](https://reactnative.dev/docs/0.81/safeareaview) react-native-safe-area-context 를 사용하여 개선합니다.

<details>
  <summary>📘 Eng ver</summary>

The `SafeAreaView` in react-native does not support the **edge-to-edge** behavior introduced in Android SDK 35 and above.  
As a result, the top and bottom content in the example project can be covered.  
To address this, I improved the implementation by using `react-native-safe-area-context`, as [recommended in the RN 0.81+ documentation](https://reactnative.dev/docs/0.81/safeareaview).

</details>


| Before | After |
|-------|-------|
| <img src="https://github.com/user-attachments/assets/7a376a51-c48a-420e-8f5d-82d4b4cd350e" width="50%" /> | <img src="https://github.com/user-attachments/assets/112bc5ef-5dc9-4dd2-ada5-8706836b7835" width="50%" /> | 


