### PR TITLE
fix(android): setup location source for tracking modes

### DIFF
--- a/android/src/main/java/com/mjstudio/reactnativenavermap/mapview/RNCNaverMapViewManager.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/mapview/RNCNaverMapViewManager.kt
@@ -831,14 +831,22 @@ class RNCNaverMapViewManager : RNCNaverMapViewManagerSpec<RNCNaverMapViewWrapper
   override fun setLocationTrackingMode(
     view: RNCNaverMapViewWrapper?,
     mode: String?,
-  ) = view.withMap {
-    it.locationTrackingMode =
-      when (mode) {
-        "NoFollow" -> LocationTrackingMode.NoFollow
-        "Follow" -> LocationTrackingMode.Follow
-        "Face" -> LocationTrackingMode.Face
-        else -> LocationTrackingMode.None
+  ) = view.withMapView { mapView ->
+    mapView.withMap { map ->
+      val trackingMode =
+        when (mode) {
+          "NoFollow" -> LocationTrackingMode.NoFollow
+          "Follow" -> LocationTrackingMode.Follow
+          "Face" -> LocationTrackingMode.Face
+          else -> LocationTrackingMode.None
+        }
+
+      if (trackingMode != LocationTrackingMode.None) {
+        mapView.setupLocationSource()
       }
+
+      map.locationTrackingMode = trackingMode
+    }
   }
 
   companion object {


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

[네이버 맵 SDK 문서](https://navermaps.github.io/android-map-sdk/guide-ko/4-2.html)에 따르면 위치 추적을 위해 `NaverMap` 에 LocationSource 를 지정해야 합니다.  `setLocationTrackingMode` 함수에 LocationSource 를 지정하는 로직이 누락되어 안드로이드에서 위치추적이 동작하지 않는 버그를 수정합니다. 

`RNCNaverMapViewManager.kt - setIsShowLocationButton` 를 참고하여 위치 추적이 필요한 경우 `setupLocationSource` 호출하여 LocationSource 를 지정하도록 합니다

<details> <summary>📘 Eng ver</summary>

According to the [Naver Map SDK documentation](https://navermaps.github.io/android-map-sdk/guide-ko/4-2.html), a LocationSource must be set on NaverMap in order to enable location tracking.
A bug occurred because LocationSource was not set, so location tracking didn’t work on Android.

Referring to `RNCNaverMapViewManager.kt - setIsShowLocationButton`, I updated the code to call setupLocationSource and set the LocationSource when location tracking is needed.

</details>
