### PR TITLE
fix(android): Support file:// and content:// URIs for marker images after CodePush

### DIFF
--- a/android/src/main/java/com/mjstudio/reactnativenavermap/util/image/GetOverlayImage.kt
+++ b/android/src/main/java/com/mjstudio/reactnativenavermap/util/image/GetOverlayImage.kt
@@ -52,7 +52,11 @@ internal fun getOverlayImage(
 
   val rnAssetUri = map["rnAssetUri"]?.toString() ?: ""
   // rnAssetUri starts with http if dev environment(metro server)
-  val httpUri = map["httpUri"]?.toString() ?: if (rnAssetUri.startsWith("http")) rnAssetUri else ""
+  // Also handle file:// and content:// URIs (e.g., from CodePush bundles)
+  val isUriFormat = rnAssetUri.startsWith("http") || 
+                     rnAssetUri.startsWith("file://") || 
+                     rnAssetUri.startsWith("content://")
+  val httpUri = map["httpUri"]?.toString() ?: if (isUriFormat) rnAssetUri else ""
   val assetName = map["assetName"]?.toString() ?: ""
   val reuseIdentifier = map["reuseIdentifier"]?.toString() ?: ""
 
@@ -110,8 +114,10 @@ internal fun getOverlayImage(
     return
   }
 
-  if (rnAssetUri.isNotEmpty() || assetName.isNotEmpty()) {
-    val name = rnAssetUri.ifEmpty { assetName }
+  // Only use drawable resource if rnAssetUri is not a URI format (file://, content://, http://, https://)
+  // and assetName is provided, or if rnAssetUri is empty and assetName is provided
+  if (assetName.isNotEmpty() || (rnAssetUri.isNotEmpty() && !isUriFormat)) {
+    val name = if (assetName.isNotEmpty()) assetName else rnAssetUri
     val key = reuseIdentifier.ifEmpty { name }
     callback(
       OverlayImage.fromResource(getDrawableWithName(context, name)).also {


### PR DESCRIPTION
<!-- Thank you for contributing package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhance (enhance performance, api, etc)
- [ ] Chore
- [ ] This change requires a documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What does this change?

- Add support for file:// and content:// URI formats in rnAssetUri
- Fix marker image loading logic to properly handle CodePush bundle URIs
- Update drawable resource condition to exclude URI-formatted rnAssetUri

Fixes #57 🎯

