### PR TITLE
fix(ios): guard against nil iconImage in marker setImage callback

### DIFF
--- a/ios/Overlay/Marker/RNCNaverMapMarker.mm
+++ b/ios/Overlay/Marker/RNCNaverMapMarker.mm
@@ -99,8 +99,10 @@ using namespace facebook::react;
 
   _imageCanceller = nmap::getImage([self bridge], image, ^(NMFOverlayImage* _Nullable image) {
     dispatch_async(dispatch_get_main_queue(), [self, image]() {
-      self.inner.alpha = 1;
-      self.inner.iconImage = image;
+      if (image) {
+        self.inner.alpha = 1;
+        self.inner.iconImage = image;
+      }
       self->_imageCanceller = nil;
       [self ensureTouchHandler]; // Re-ensure touch handler after image is set
     });

--- a/ios/Overlay/Marker/RNCNaverMapMarker.mm
+++ b/ios/Overlay/Marker/RNCNaverMapMarker.mm
@@ -99,8 +99,8 @@ using namespace facebook::react;
 
   _imageCanceller = nmap::getImage([self bridge], image, ^(NMFOverlayImage* _Nullable image) {
     dispatch_async(dispatch_get_main_queue(), [self, image]() {
+      self.inner.alpha = 1;
       if (image) {
-        self.inner.alpha = 1;
         self.inner.iconImage = image;
       }
       self->_imageCanceller = nil;


### PR DESCRIPTION
## Summary
- Add nil check before setting `NMFMarker.iconImage` in the `getImage` callback to prevent crash when image is nil

## Problem
`NMFMarker` crashes with `SIGABRT` when `iconImage` is set to `nil`. This occurs when `nmap::getImage` returns `nil` via callback (e.g., image load failure, unsupported symbol name).

**Crash stack:**
```
-[NMFMarker setIconImage:] (NMFMarker)
-[RNCNaverMapMarker setImage:]::block (RNCNaverMapMarker.mm:103)
```

## Root Cause
`ImageUtil.h`'s `getImage` can call `callback(nil)` in two places (line 80, line 112), but `RNCNaverMapMarker.mm:103` sets `self.inner.iconImage = image` without nil check.

## Fix
One-line nil guard before setting iconImage.

Fixes #183

🤖 Generated with [Claude Code](https://claude.ai/claude-code)