### PR TITLE
fix: apply default location overlay anchor

### DIFF
--- a/example/src/screens/LocationOverlayScreen.tsx
+++ b/example/src/screens/LocationOverlayScreen.tsx
@@ -32,7 +32,6 @@ export const LocationOverlayScreen = ({ onBack }: { onBack: () => void }) => {
                 },
                 bearing: locationOverlayBearing,
                 image: require('../logo180.png'),
-                anchor: { x: 0.5, y: 0.5 },
                 subImage: { symbol: 'green' },
                 subImageWidth: 72,
                 subImageHeight: 72,

--- a/src/component/NaverMapView.tsx
+++ b/src/component/NaverMapView.tsx
@@ -685,6 +685,8 @@ const nullCamera: Camera = {
   bearing: Const.NULL_NUMBER,
 };
 
+const defaultLocationOverlayAnchor = { x: 0.5, y: 0.5 };
+
 export const NaverMapView = forwardRef(
   (
     {
@@ -819,13 +821,13 @@ export const NaverMapView = forwardRef(
             : undefined,
           imageWidth: locationOverlay.imageWidth,
           imageHeight: locationOverlay.imageHeight,
-          anchor: locationOverlay.anchor,
+          anchor: locationOverlay.anchor ?? defaultLocationOverlayAnchor,
           subImage: locationOverlay.subImage
             ? convertJsImagePropToNativeProp(locationOverlay.subImage)
             : undefined,
           subImageWidth: locationOverlay.subImageWidth,
           subImageHeight: locationOverlay.subImageHeight,
-          subAnchor: locationOverlay.subAnchor,
+          subAnchor: locationOverlay.subAnchor ?? defaultLocationOverlayAnchor,
           circleRadius: locationOverlay.circleRadius,
           circleColor: locationOverlay.circleColor
             ? (processColor(locationOverlay.circleColor) as number)


### PR DESCRIPTION
## Summary
- Apply the documented `{ x: 0.5, y: 0.5 }` default anchor for `locationOverlay` and `subAnchor` before native handoff.
- Remove the explicit anchor from the example Location Overlay screen so it exercises the default behavior.

## Root Cause
When `locationOverlay.anchor` was omitted, the Fabric iOS struct received the codegen numeric default (`0`), so the iOS location overlay anchor became the top-left corner instead of the documented center point. This caused the overlay icon to appear to drift when zoom changed.

## Validation
- `pnpm typecheck`
- `pnpm run t`
- iOS simulator check with `agent-device`: opened the example app, navigated to Location Overlay, verified the screen using the default anchor, and exercised zoom in/out plus bearing controls.

Fixes #172