### PR TITLE
Centralize iOS thread utilities

### DIFF
--- a/ios/Module/RNCNaverMapUtil.mm
+++ b/ios/Module/RNCNaverMapUtil.mm
@@ -6,6 +6,7 @@
 //
 
 #import "RNCNaverMapUtil.h"
+#import "FnUtil.h"
 #import <Foundation/Foundation.h>
 
 static NSMutableDictionary<NSString*, NMFInfoWindow*>* RNCNaverMapInfoWindows(void) {
@@ -30,21 +31,12 @@ static BOOL RNCNaverMapInfoWindowIsOpen(NMFInfoWindow* infoWindow) {
   return infoWindow.marker != nil || infoWindow.mapView != nil;
 }
 
-static void RNCNaverMapRunOnMainSync(dispatch_block_t block) {
-  if (NSThread.isMainThread) {
-    block();
-    return;
-  }
-
-  dispatch_sync(dispatch_get_main_queue(), block);
-}
-
 @implementation RNCNaverMapUtil
 
 RCT_EXPORT_MODULE()
 
 - (void)createInfoWindow:(NSString*)infoWindowId {
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     if (RNCNaverMapInfoWindows()[infoWindowId])
       return;
 
@@ -59,7 +51,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)destroyInfoWindow:(NSString*)infoWindowId {
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     NMFInfoWindow* infoWindow = RNCNaverMapInfoWindows()[infoWindowId];
     if (infoWindow) {
       [infoWindow close];
@@ -70,7 +62,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)closeInfoWindow:(NSString*)infoWindowId {
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     NMFInfoWindow* infoWindow = RNCNaverMapInfoWindows()[infoWindowId];
     if (infoWindow) {
       [infoWindow close];
@@ -79,7 +71,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)setInfoWindowContent:(NSString*)infoWindowId text:(NSString*)text {
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     RNCNaverMapInfoWindowContents()[infoWindowId] = text ?: @"";
 
     NMFInfoWindow* infoWindow = RNCNaverMapInfoWindows()[infoWindowId];
@@ -102,7 +94,7 @@ RCT_EXPORT_MODULE()
                      offsetX:(double)offsetX
                      offsetY:(double)offsetY
                        alpha:(double)alpha {
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     NMFInfoWindow* infoWindow = RNCNaverMapInfoWindows()[infoWindowId];
     if (infoWindow) {
       infoWindow.anchor = CGPointMake(anchorX, anchorY);
@@ -115,7 +107,7 @@ RCT_EXPORT_MODULE()
 
 - (NSNumber*)isInfoWindowOpen:(NSString*)infoWindowId {
   __block BOOL isOpen = NO;
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     NMFInfoWindow* infoWindow = RNCNaverMapInfoWindows()[infoWindowId];
     isOpen = RNCNaverMapInfoWindowIsOpen(infoWindow);
   });
@@ -123,7 +115,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)invalidate {
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     for (NMFInfoWindow* infoWindow in RNCNaverMapInfoWindows().allValues) {
       [infoWindow close];
     }
@@ -141,7 +133,7 @@ RCT_EXPORT_MODULE()
     return;
   }
 
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     for (NMFInfoWindow* infoWindow in RNCNaverMapInfoWindows().allValues) {
       if (infoWindow.mapView == mapView || infoWindow.marker.mapView == mapView) {
         [infoWindow close];
@@ -155,7 +147,7 @@ RCT_EXPORT_MODULE()
     return;
   }
 
-  RNCNaverMapRunOnMainSync(^{
+  runOnMainSync(^{
     for (NMFInfoWindow* infoWindow in RNCNaverMapInfoWindows().allValues) {
       if (infoWindow.marker == marker) {
         [infoWindow close];

--- a/ios/Overlay/Circle/RNCNaverMapCircle.h
+++ b/ios/Overlay/Circle/RNCNaverMapCircle.h
@@ -8,7 +8,6 @@
 #import "ColorUtil.h"
 #import "FnUtil.h"
 #import "MacroUtil.h"
-#import "Utils.h"
 #import <Foundation/Foundation.h>
 #import <NMapsMap/NMapsMap.h>
 #import <React/RCTUtils.h>

--- a/ios/Overlay/Cluster/RNCNaverMapLeafMarkerUpdater.mm
+++ b/ios/Overlay/Cluster/RNCNaverMapLeafMarkerUpdater.mm
@@ -49,7 +49,7 @@
     _imgRequests->erase(idStr);
   }
   (*_imgRequests)[idStr] = nmap::getImage(image, ^(NMFOverlayImage* _Nullable overlayImage) {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    runOnMain(^{
       if (weakMarker) {
         weakMarker.alpha = 1;
         weakMarker.iconImage = !overlayImage ? NMF_MARKER_IMAGE_GREEN : overlayImage;

--- a/ios/Overlay/Ground/RNCNaverMapGround.mm
+++ b/ios/Overlay/Ground/RNCNaverMapGround.mm
@@ -84,7 +84,7 @@ static NSMutableDictionary* _overlayImageHolder;
     }
 
     _imageCanceller = nmap::getImage(next.image, ^(NMFOverlayImage* image) {
-      dispatch_async(dispatch_get_main_queue(), [self, image]() {
+      runOnMain([self, image]() {
         self.inner.alpha = 1;
         self.inner.overlayImage = image;
         self->_imageCanceller = nil;

--- a/ios/Overlay/Marker/RNCNaverMapMarker.mm
+++ b/ios/Overlay/Marker/RNCNaverMapMarker.mm
@@ -96,7 +96,7 @@ using namespace facebook::react;
   }
 
   _imageCanceller = nmap::getImage(image, ^(NMFOverlayImage* _Nullable image) {
-    dispatch_async(dispatch_get_main_queue(), [self, image]() {
+    runOnMain([self, image]() {
       self.inner.alpha = 1;
       if (image) {
         self.inner.iconImage = image;
@@ -126,7 +126,7 @@ using namespace facebook::react;
   _isImageSetFromSubview = YES;
   _inner.alpha = 0;
   // prevent default image is set after this logic in old arch
-  dispatch_async(dispatch_get_main_queue(), [self, subview]() {
+  runOnMain([self, subview]() {
     self.inner.alpha = 1;
     self.inner.iconImage = [NMFOverlayImage overlayImageWithImage:[self captureView:subview]];
     [self ensureTouchHandler]; // Re-ensure touch handler after custom marker image is set

--- a/ios/Overlay/MultiPath/RNCNaverMapMultiPath.mm
+++ b/ios/Overlay/MultiPath/RNCNaverMapMultiPath.mm
@@ -88,8 +88,7 @@ using namespace facebook::react;
     }
 
     _imageCanceller = nmap::getImage(next.patternImage, ^(NMFOverlayImage* _Nullable image) {
-      dispatch_async(dispatch_get_main_queue(),
-                     [self, image]() { self.inner.patternIcon = image; });
+      runOnMain([self, image]() { self.inner.patternIcon = image; });
     });
   }
   if (prev.patternInterval != next.patternInterval)

--- a/ios/Overlay/Path/RNCNaverMapPath.mm
+++ b/ios/Overlay/Path/RNCNaverMapPath.mm
@@ -86,8 +86,7 @@ using namespace facebook::react;
     }
 
     _imageCanceller = nmap::getImage(next.patternImage, ^(NMFOverlayImage* _Nullable image) {
-      dispatch_async(dispatch_get_main_queue(),
-                     [self, image]() { self.inner.patternIcon = image; });
+      runOnMain([self, image]() { self.inner.patternIcon = image; });
     });
   }
   if (prev.patternInterval != next.patternInterval)

--- a/ios/Overlay/Polygon/RNCNaverMapPolygon.h
+++ b/ios/Overlay/Polygon/RNCNaverMapPolygon.h
@@ -8,7 +8,6 @@
 #import "ColorUtil.h"
 #import "FnUtil.h"
 #import "MacroUtil.h"
-#import "Utils.h"
 #import <Foundation/Foundation.h>
 #import <NMapsMap/NMapsMap.h>
 #import <React/RCTUtils.h>

--- a/ios/Overlay/Polyline/RNCNaverMapPolyline.h
+++ b/ios/Overlay/Polyline/RNCNaverMapPolyline.h
@@ -8,7 +8,6 @@
 #import "ColorUtil.h"
 #import "FnUtil.h"
 #import "MacroUtil.h"
-#import "Utils.h"
 #import <Foundation/Foundation.h>
 #import <NMapsMap/NMapsMap.h>
 #import <React/RCTUtils.h>

--- a/ios/RNCNaverMapView.h
+++ b/ios/RNCNaverMapView.h
@@ -13,7 +13,6 @@
 #import "FnUtil.h"
 #import "RCTFabricComponentsPlugins.h"
 #import "RNCNaverMapViewImpl.h"
-#import "Utils.h"
 
 @interface RNCNaverMapView : RCTViewComponentView
 

--- a/ios/RNCNaverMapViewImpl.h
+++ b/ios/RNCNaverMapViewImpl.h
@@ -21,7 +21,6 @@
 #import "RNCNaverMapPath.h"
 #import "RNCNaverMapPolygon.h"
 #import "RNCNaverMapPolyline.h"
-#import "Utils.h"
 #import <Foundation/Foundation.h>
 #import <NMapsGeometry/NMapsGeometry.h>
 #import <NMapsMap/NMapsMap.h>

--- a/ios/RNCNaverMapViewImpl.mm
+++ b/ios/RNCNaverMapViewImpl.mm
@@ -41,9 +41,7 @@
     [self.mapView addOptionDelegate:self];
 
     // run after _eventEmitter available(new arch), direct event block set(old arch)
-    double delayInSeconds = 0.1;
-    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
-    dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
+    runOnMainAfter(0.1, ^{
       if (!self.rncParent.emitter)
         return;
 
@@ -260,7 +258,7 @@
     }
 
     _mainImageCanceller = nmap::getImage(locationOverlay.image, ^(NMFOverlayImage* image) {
-      dispatch_async(dispatch_get_main_queue(), [self, image]() {
+      runOnMain([self, image]() {
         self.mapView.locationOverlay.icon = image;
         self->_mainImageCanceller = nil;
       });
@@ -279,7 +277,7 @@
     }
 
     _subImageCanceller = nmap::getImage(locationOverlay.subImage, ^(NMFOverlayImage* image) {
-      dispatch_async(dispatch_get_main_queue(), [self, image]() {
+      runOnMain([self, image]() {
         self.mapView.locationOverlay.subIcon = image;
         self->_subImageCanceller = nil;
       });

--- a/ios/Util/FnUtil.h
+++ b/ios/Util/FnUtil.h
@@ -4,9 +4,32 @@
 //
 //  Created by mj on 4/3/24.
 //
+#import <Foundation/Foundation.h>
 #import <NMapsMap/NMapsMap.h>
 #import <string>
 #import <utility>
+
+static inline void runOnMain(dispatch_block_t block) {
+  dispatch_async(dispatch_get_main_queue(), block);
+}
+
+static inline void runOnMainSync(dispatch_block_t block) {
+  if (NSThread.isMainThread) {
+    block();
+    return;
+  }
+
+  dispatch_sync(dispatch_get_main_queue(), block);
+}
+
+static inline void runOnMainAfter(double delayInSeconds, dispatch_block_t block) {
+  dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
+  dispatch_after(popTime, dispatch_get_main_queue(), block);
+}
+
+static inline void runOnBackground(dispatch_block_t block) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), block);
+}
 
 static inline BOOL isValidNumber(NSNumber* value) {
   if (!value || [value isKindOfClass:[NSNull class]]) {

--- a/ios/Util/Image/RNCNaverMapOverlayImageLoader.mm
+++ b/ios/Util/Image/RNCNaverMapOverlayImageLoader.mm
@@ -1,4 +1,5 @@
 #import "RNCNaverMapOverlayImageLoader.h"
+#import "FnUtil.h"
 
 static NSString* const RNCNaverMapOverlayImageLoaderErrorDomain =
     @"RNCNaverMapOverlayImageLoaderErrorDomain";
@@ -18,25 +19,20 @@ static NSError* RNCNaverMapOverlayImageLoaderError(NSString* description) {
                          userInfo:@{NSLocalizedDescriptionKey : description}];
 }
 
-static void RNCNaverMapCompleteOnMain(RNCNaverMapUIImageHandler completion,
-                                      UIImage* _Nullable image, NSError* _Nullable error) {
-  dispatch_async(dispatch_get_main_queue(), ^{
-    completion(image, error);
-  });
-}
-
 RNCNaverMapImageCanceller RNCNaverMapLoadUIImageWithUri(NSString* uriString,
                                                         RNCNaverMapUIImageHandler completion) {
   NSURL* url = [NSURL URLWithString:uriString];
   if (!url || url.scheme.length == 0) {
     UIImage* image = [UIImage imageNamed:uriString];
-    RNCNaverMapCompleteOnMain(completion, image, nil);
+    runOnMain(^{
+      completion(image, nil);
+    });
     return RNCNaverMapNoopCanceller();
   }
 
   if (url.fileURL) {
     __block BOOL isCancelled = NO;
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    runOnBackground(^{
       if (isCancelled) {
         return;
       }
@@ -57,7 +53,9 @@ RNCNaverMapImageCanceller RNCNaverMapLoadUIImageWithUri(NSString* uriString,
         return;
       }
 
-      RNCNaverMapCompleteOnMain(completion, image, error);
+      runOnMain(^{
+        completion(image, error);
+      });
     });
 
     return ^{
@@ -76,7 +74,9 @@ RNCNaverMapImageCanceller RNCNaverMapLoadUIImageWithUri(NSString* uriString,
             if (error.code == NSURLErrorCancelled) {
               return;
             }
-            RNCNaverMapCompleteOnMain(completion, nil, error);
+            runOnMain(^{
+              completion(nil, error);
+            });
             return;
           }
 
@@ -87,7 +87,9 @@ RNCNaverMapImageCanceller RNCNaverMapLoadUIImageWithUri(NSString* uriString,
             imageError = RNCNaverMapOverlayImageLoaderError(@"Failed to decode image");
           }
 
-          RNCNaverMapCompleteOnMain(completion, image, imageError);
+          runOnMain(^{
+            completion(image, imageError);
+          });
         }];
   [task resume];
 


### PR DESCRIPTION
## Summary
- Move iOS thread helpers into FnUtil.h as runOnMain, runOnMainSync, runOnMainAfter, and runOnBackground.
- Replace direct main/background dispatch calls with the shared helpers.
- Remove stale Utils.h imports from iOS headers.

## Validation
- pnpm pod
- pnpm run t
- pnpm ci:ios was intentionally not used for final local validation because CI runs it on GitHub per request.