### PR TITLE
chore: replace object-hash with ohash

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@expo/config-plugins": "10.0.3",
     "@release-it/conventional-changelog": "^10.0.1",
     "@types/fs-extra": "^11",
-    "@types/object-hash": "^3",
     "@types/react": "catalog:",
     "commitlint": "17.0.2",
     "fs-extra": "^11.3.1",
@@ -175,7 +174,7 @@
     }
   },
   "dependencies": {
-    "object-hash": "^3.0.0"
+    "ohash": "^2.0.11"
   },
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,9 @@ importers:
 
   .:
     dependencies:
-      object-hash:
-        specifier: ^3.0.0
-        version: 3.0.0
+      ohash:
+        specifier: ^2.0.11
+        version: 2.0.11
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -99,9 +99,6 @@ importers:
       '@types/fs-extra':
         specifier: ^11
         version: 11.0.4
-      '@types/object-hash':
-        specifier: ^3
-        version: 3.0.6
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.6
@@ -2417,9 +2414,6 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
-  '@types/object-hash@3.0.6':
-    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
-
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
@@ -4699,10 +4693,6 @@ packages:
   ob1@0.84.3:
     resolution: {integrity: sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -8359,8 +8349,6 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@types/object-hash@3.0.6': {}
-
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
@@ -11017,8 +11005,6 @@ snapshots:
   ob1@0.84.3:
     dependencies:
       flow-enums-runtime: 0.0.6
-
-  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 

--- a/src/component/NaverMapMarkerOverlay.tsx
+++ b/src/component/NaverMapMarkerOverlay.tsx
@@ -1,4 +1,4 @@
-import hash from 'object-hash';
+import { hash } from 'ohash';
 import React, {
   Children,
   type ForwardedRef,

--- a/src/component/NaverMapView.tsx
+++ b/src/component/NaverMapView.tsx
@@ -1,4 +1,4 @@
-import hash from 'object-hash';
+import { hash } from 'ohash';
 
 import React, {
   type ForwardedRef,


### PR DESCRIPTION
## Summary
- Replace `object-hash` imports with `ohash` named `hash` imports.
- Remove `object-hash` and `@types/object-hash` from direct dependencies.
- Add `ohash` as the direct runtime dependency.

## Verification
- `pnpm run t`
- `pnpm biome check src/component/NaverMapMarkerOverlay.tsx src/component/NaverMapView.tsx package.json`
- `git diff --check`

## Review
- Code review completed with no Critical, Important, or Minor issues found.